### PR TITLE
feat: strip `node:` prefixes from our dists

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,6 +3,26 @@ import type { Options } from 'tsup';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { defineConfig } from 'tsup';
 
+/**
+ * Webpack unfortunately does not support the `node:` prefix making it impossible to polyfill the
+ * `node:stream` and `node:util` libraries that we use here so we're removing it when we generate
+ * our dists.
+ *
+ * @see {@link https://github.com/evanw/esbuild/issues/1760#issuecomment-964900401}
+ * @see {@link https://github.com/webpack/webpack/issues/14166}
+ */
+const stripNodeColonPlugin = {
+  name: 'strip-node-colon',
+  setup({ onResolve }) {
+    onResolve({ filter: /^node:/ }, args => {
+      return {
+        path: args.path.slice('node:'.length),
+        external: true,
+      };
+    });
+  },
+};
+
 export default defineConfig((options: Options) => ({
   ...options,
 
@@ -10,6 +30,7 @@ export default defineConfig((options: Options) => ({
   clean: true,
   dts: true,
   entry: ['src/index.ts'],
+  esbuildPlugins: [stripNodeColonPlugin],
   format: ['esm', 'cjs'],
   minify: false,
   shims: true,


### PR DESCRIPTION
## 🧰 Changes

I learned this evening that despite adding support for `node:` protocols in Webpack 5.40[^1] it doesn't support them in `resolve.fallback` or `resolve.alias`[^2] which is making it impossible to compile this library, by way of `@readme/httpsnippet` and `@readme/oas-to-snippet`, in our main app:

<img width="764" alt="Screen Shot 2023-11-07 at 11 55 49 PM" src="https://github.com/readmeio/formdata-to-string/assets/33762/75f834bb-9e89-4bef-b0b8-92fccfe13a7b">

This is a tough one because I hate this ESBuild plugin I found but also I do kind of like the `node:` prefix, eventhough it doesn't really do anything other than adding visual sugar[^3],  but maybe instead of stripping it from our dists we should just stop using it all together and remove the [unicorn/prefer-node-protocol](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-node-protocol.md) rule from our ESM ESLint config[^4]? 

## 🧬 QA & Testing

### Before

Curiously `tsup` and `esbuild` already remove it for CJS builds.

![Screen Shot 2023-11-08 at 12 01 21 AM](https://github.com/readmeio/formdata-to-string/assets/33762/10e01355-526e-485f-8cc7-d6844e2b6d77)

### After

![Screen Shot 2023-11-08 at 12 01 31 AM](https://github.com/readmeio/formdata-to-string/assets/33762/d7faa969-3a12-4ea3-925b-8a804a5d83b7)

[^1]: https://github.com/webpack/webpack/commit/de5365bf426ac0c39ee6905ec15541cd22090574
[^2]: https://github.com/webpack/webpack/issues/14166
[^3]: https://nodejs.org/docs/latest-v18.x/api/esm.html#node-imports
[^4]: https://github.com/readmeio/standards/blob/main/packages/eslint-config/esm.js#L12